### PR TITLE
API: add support for non V4 16S data

### DIFF
--- a/q2_gg2/__init__.py
+++ b/q2_gg2/__init__.py
@@ -10,7 +10,7 @@ from ._methods import (taxonomy_from_table, taxonomy_from_features,
                        bulk_clade_v4_asv_assessment,
                        sequence_v4_asv_assessment,
                        bulk_sequence_v4_asv_assessment, clade_lookup,
-                       compute_effect_size)
+                       compute_effect_size, non_v4_16s)
 from . import _version
 __version__ = _version.get_versions()['version']
 __all__ = ['taxonomy_from_table', 'taxonomy_from_features',
@@ -18,4 +18,4 @@ __all__ = ['taxonomy_from_table', 'taxonomy_from_features',
            'bulk_clade_v4_asv_assessment', 'clade_lookup',
            'sequence_v4_asv_assessment',
            'bulk_sequence_v4_asv_assessment',
-           'compute_effect_size']
+           'compute_effect_size', 'non_v4_16s']

--- a/q2_gg2/_methods.py
+++ b/q2_gg2/_methods.py
@@ -895,4 +895,3 @@ def non_v4_16s(ctx, table, sequences, backbone, perc_identity=0.99, threads=1):
                                                 perc_identity=perc_identity,
                                                 threads=threads)
     return res_table, res_seqs
-

--- a/q2_gg2/_methods.py
+++ b/q2_gg2/_methods.py
@@ -887,3 +887,12 @@ def compute_effect_size(output_dir: str,
         'q2_gg2', 'compute_effect_size_assets')
     index = os.path.join(TEMPLATES, 'index.html')
     q2templates.render(index, output_dir, context={})
+
+
+def non_v4_16s(ctx, table, sequences, backbone, perc_identity=0.99, threads=1):
+    action = ctx.get_action('vsearch', 'cluster_features_closed_reference')
+    res_table, res_seqs, res_unmatched = action(sequences, table, backbone,
+                                                perc_identity=perc_identity,
+                                                threads=threads)
+    return res_table, res_seqs
+

--- a/q2_gg2/plugin_setup.py
+++ b/q2_gg2/plugin_setup.py
@@ -7,7 +7,7 @@
 # ----------------------------------------------------------------------------
 
 import importlib
-from qiime2.plugin import Plugin, Bool, Int, List, Str, Metadata
+from qiime2.plugin import Plugin, Bool, Int, List, Str, Metadata, Float
 from q2_types.feature_table import FeatureTable, Frequency
 from q2_types.feature_data import FeatureData, Taxonomy, Sequence
 from q2_types.tree import Phylogeny, Rooted
@@ -53,6 +53,31 @@ plugin.register_semantic_type_to_format(
 plugin.register_semantic_type_to_format(
     ASVAssessment,
     artifact_format=ASVAssessmentDirFmt
+)
+
+
+plugin.pipelines.register_function(
+    function=q2_gg2.non_v4_16s,
+    inputs={'table': FeatureTable[Frequency],
+            'sequences': FeatureData[Sequence],
+            'backbone': FeatureData[Sequence]},
+    parameters={'threads': Int,
+                'perc_identity': Float},
+    outputs=[('mapped_table', FeatureTable[Frequency]),
+             ('representatives', FeatureData[Sequence])],
+    input_descriptions={
+        'table': 'A precomputed feature table (e.g., from Deblur)',
+        'sequences': 'The sequence data to characterize',
+        'backbone': 'The set of backbone sequences in Greengenes2'},
+    parameter_descriptions={
+        'threads': 'The number of threads to use on characterization',
+        'perc_identity': 'The percent identity at which to cluster'},
+    output_descriptions={
+        'mapped_table': 'The resulting feature table',
+        'representatives': 'The representative backbone tips'},
+    name='Non V4 16S sequence assessment',
+    description=("Characterize through closed reference OTU picking the "
+                 "the input feature table against Greengenes2")
 )
 
 


### PR DESCRIPTION
As the subject notes. The strategy is to perform closed reference OTU picking against the backbone using vsearch 