### PR TITLE
Collapse multifurcation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Greengenes2 changelog
 
-## Version 2022.4-dev
+## Version 2022.12
+
+* Added a method for collapsing by multifurcation in [#5](https://github.com/biocore/q2-greengenes2/pull/5)
+
+## Version 2022.10
+
+* Support for filtering a feature table against Greengenes2 by @wasade
+* new plugin to compute effect sizes by @giorgianicolaou in [#2](https://github.com/biocore/q2-greengenes2/pull/2)
+* Bulk characterization methods @wasade in [#3](https://github.com/biocore/q2-greengenes2/pull/3)
+* Support for non V4 16S data by @wasade in [#4](https://github.com/biocore/q2-greengenes2/pull/4)
+
+## Version 2022.4
 
 ### Features
 

--- a/q2_gg2/__init__.py
+++ b/q2_gg2/__init__.py
@@ -9,6 +9,7 @@ from ._methods import (taxonomy_from_table, taxonomy_from_features,
                        filter_features, relabel, clade_v4_asv_assessment,
                        bulk_clade_v4_asv_assessment,
                        sequence_v4_asv_assessment,
+                       collapse_multifurcation,
                        bulk_sequence_v4_asv_assessment, clade_lookup,
                        compute_effect_size, non_v4_16s)
 from . import _version
@@ -18,4 +19,5 @@ __all__ = ['taxonomy_from_table', 'taxonomy_from_features',
            'bulk_clade_v4_asv_assessment', 'clade_lookup',
            'sequence_v4_asv_assessment',
            'bulk_sequence_v4_asv_assessment',
+           'collapse_multifurcation',
            'compute_effect_size', 'non_v4_16s']

--- a/q2_gg2/_methods.py
+++ b/q2_gg2/_methods.py
@@ -907,7 +907,7 @@ def collapse_multifurcation(feature_table: biom.Table,
     # determine which regex to use with the table
     regex = None
     for r in regexs:
-        if r.match(table.ids(axis='observation')[0]):
+        if r.match(feature_table.ids(axis='observation')[0]):
             regex = r
             break
 
@@ -923,7 +923,7 @@ def collapse_multifurcation(feature_table: biom.Table,
 
     phylogeny_tips = {phylogeny.name(i) for i in range(len(phylogeny.B) - 1)
                       if phylogeny.B[i] and not phylogeny.B[i+1]}
-    overlap = phylogeny_tips & set(table.ids(axis='observation'))
+    overlap = phylogeny_tips & set(feature_table.ids(axis='observation'))
 
     # bail early if something is weird
     if not overlap:
@@ -959,7 +959,7 @@ def collapse_multifurcation(feature_table: biom.Table,
                     collapse_map[c.name] = n.name
 
     # collapse the feature table to the multifurcation
-    table = table.collapse(lambda i, m: collapse_map.get(i, i),
-                           axis='observation', norm=False)
+    table = feature_table.collapse(lambda i, m: collapse_map.get(i, i),
+                                   axis='observation', norm=False)
     table.del_metadata()
     return table, phylogeny

--- a/q2_gg2/_methods.py
+++ b/q2_gg2/_methods.py
@@ -931,7 +931,7 @@ def collapse_multifurcation(feature_table: biom.Table,
 
     # reduce the phylogeny
     phylogeny = phylogeny.shear(overlap).collapse()
-    phylogeny = bp.to_skbio_phylogenynode(phylogeny)
+    phylogeny = bp.to_skbio_treenode(phylogeny)
 
     # remark what appears to be an asv in the phylogeny
     for n in phylogeny.non_tips(include_self=True):

--- a/q2_gg2/plugin_setup.py
+++ b/q2_gg2/plugin_setup.py
@@ -331,4 +331,27 @@ plugin.visualizers.register_function(
     citations=[]
 )
 
+
+plugin.methods.register_function(
+    function=q2_gg2.collapse_multifurcation,
+    inputs={'feature_table': FeatureTable[Frequency],
+            'phylogeny': ReferenceMap},
+    parameters={},
+    outputs=[('collapsed_table', FeatureTable[Frequency]),
+             ('collapsed_phylogeny', Phylogeny[Rooted])],
+    input_descriptions={
+        'feature_table': "The feature table to collapse",
+        'phylogeny': "The reference phylogeny"},
+    parameter_descriptions={},
+    output_descriptions={
+        'collapsed_table': 'The resulting collapsed feature table',
+        'collapsed_phylogeny': ('The phylogeny filtered with multifurcations '
+                                'collapsed')},
+    name='Collapse features present within multifurcations',
+    description=("Collapse features present within multifurcations. This is "
+                 "a phylogenetic feature space reduction technique. "),
+    citations=[]
+)
+
+
 importlib.import_module('q2_gg2._transformer')

--- a/q2_gg2/plugin_setup.py
+++ b/q2_gg2/plugin_setup.py
@@ -335,7 +335,7 @@ plugin.visualizers.register_function(
 plugin.methods.register_function(
     function=q2_gg2.collapse_multifurcation,
     inputs={'feature_table': FeatureTable[Frequency],
-            'phylogeny': ReferenceMap},
+            'phylogeny': Phylogeny[Rooted]},
     parameters={},
     outputs=[('collapsed_table', FeatureTable[Frequency]),
              ('collapsed_phylogeny', Phylogeny[Rooted])],

--- a/q2_gg2/tests/test_methods.py
+++ b/q2_gg2/tests/test_methods.py
@@ -57,7 +57,7 @@ class GG2MethodTests(unittest.TestCase):
                                        [48, 51, 54, 57]]),
                              ['x', 30000000, 'z'],
                              list('abcd'))
-        exp_tree = skbio.TreeNode.read(["(((x,G1),(30000000,G2)y),(z,(G3,G4)));"])
+        exp_tree = skbio.TreeNode.read(["(((x,G1),(30000000,G2)y),(z,(G3,G4)));"])  # noqa
         obs_tab, obs_tree = collapse_multifurcation(table, tree)
         self.assertEqual(obs_tab, exp_tab)
         self.assertEqual(obs_tree.compare_rfd(exp_tree), 0.)

--- a/q2_gg2/tests/test_methods.py
+++ b/q2_gg2/tests/test_methods.py
@@ -24,6 +24,7 @@ from q2_gg2._methods import (_load_tree_and_cache,
                              _infer_feature_data_labels,
                              _sequence_v4_asv_assessment,
                              filter_features,
+                             collapse_multifurcation,
                              taxonomy_from_features,
                              taxonomy_from_table,
                              relabel,
@@ -44,6 +45,22 @@ class GG2MethodTests(unittest.TestCase):
                         ">X\nA\n"
                         ">Y\nA\n"
                         ">Z\nA\n")
+
+    def test_collapse_multifurcation(self):
+        table = biom.Table(np.arange(24).reshape(6, 4),
+                           ['10000000', '20000000', '30000000',
+                            '40000000', '50000000', '60000000'],
+                           list('abcd'))
+        tree = io.StringIO("((((10000000,20000000)x,G1),(30000000,G2)y),((40000000,50000000,60000000)z,(G3,G4)));")  # noqa
+        exp_tab = biom.Table(np.array([[4, 6, 8, 10],
+                                       [8, 9, 10, 11],
+                                       [48, 51, 54, 57]]),
+                             ['x', 30000000, 'z'],
+                             list('abcd'))
+        exp_tree = skbio.TreeNode.read(["(((x,G1),(30000000,G2)y),(z,(G3,G4)));"])
+        obs_tab, obs_tree = collapse_multifurcation(table, tree)
+        self.assertEqual(obs_tab, exp_tab)
+        self.assertEqual(obs_tree.compare_rfd(exp_tree), 0.)
 
     def test_infer_feature_data_labels(self):
         taxa = pd.DataFrame([['MJ007-1-barcode27-umi40bins-ubs-7010', 's__foo',

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,15 @@ from setuptools import setup, find_packages
 
 import versioneer
 
+
+install_requires = [
+    "biom-format",
+    "iow",
+    "redbiom",
+    "scikit-bio"
+]
+
+
 setup(
     name="q2-greengenes2",
     version=versioneer.get_version(),
@@ -19,4 +28,5 @@ setup(
         'q2_gg2': []
     },
     zip_safe=False,
+    install_requires=install_requires,
 )


### PR DESCRIPTION
Allows a user to take a table of ASVs and reduce the feature space phylogenetically by collapsing multifurcations the ASVs are placed in. 